### PR TITLE
Minor bug fixed

### DIFF
--- a/lib/down_day.py
+++ b/lib/down_day.py
@@ -107,7 +107,7 @@ def down_day(targetVar, pred_scene, saf_scene, var_scene, pred_calib, saf_calib,
 
         # Downscale at point level
         else:
-            if pred_scene != None:
+            if np.any(pred_scene != None) == True:
                 # Adds axis so scene and calib have the same dimensions
                 pred_scene = pred_scene[np.newaxis, :, :, :]
 


### PR DESCRIPTION
Al hacer el downscaling con ANA-LOC-kNN salió otro error distinito de los que habíamos visto esta mañana y que se habían solucionado. El nuevo error era este:

==> 2738008.err <==
Traceback (most recent call last):
  File "/clim/clt/pyClim-SDM-1/src/../lib/down_scene_ANA.py", line 381, in <module>
    downscale_chunk(targetVar, methodName, family, mode, fields, scene, model, iproc, nproc)
  File "/clim/clt/pyClim-SDM-1/src/../lib/down_scene_ANA.py", line 269, in downscale_chunk
    est[idate] = down_day.down_day(targetVar, pred_scene_idate, saf_scene_idate, var_scene_idate, pred_calib, saf_calib,
  File "/clim/clt/pyClim-SDM-1/lib/down_day.py", line 110, in down_day
    if pred_scene != None:
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
srun: error: cirrus1263: task 33: Exited with exit code 1
srun: error: cirrus1263: tasks 0-32,34-49: Exited with exit code 1

y creo que lo he corregido con este commit porque el downscaling del fold1 ha terminado sin errores. En cualquier caso, míralo antes de aceptar por si hay algo que yo no haya tenido en cuenta.