### PR TITLE
Minor improvement: CLIMDEX netXCDF writting

### DIFF
--- a/lib/postpro_lib.py
+++ b/lib/postpro_lib.py
@@ -104,7 +104,7 @@ def calculate_all_climdex(pathOut, filename, targetVar, data, times, ref, times_
             # Save results
             # np.save(pathOut+'_'.join((climdex_name, filename, season)), data_climdex)
             times_years = list(dict.fromkeys([datetime.datetime(x.year, 1, 1, 12, 0) for x in times_season]))
-            write.netCDF(pathOut, '_'.join((climdex_name, filename, season))+'.nc', climdex_name, data_climdex, '',
+            write.netCDF(pathOut, '_'.join((climdex_name, filename, season))+'.nc', targetVar+'_'+climdex_name, data_climdex, '',
                          hres_lats[targetVar], hres_lons[targetVar], times_years, regular_grid=False)
 
     print(targetVar, filename, 'calculate_all_climdex', str(datetime.datetime.now() - start))

--- a/lib/write.py
+++ b/lib/write.py
@@ -75,8 +75,12 @@ def netCDF(path, filename, varName, data, units, lats, lons, dates, regular_grid
 	timeVar.long_name = "Time variable"
 	timeVar.units = 'hours since 1900-01-01 00:00:0.0'
 	timeVar[:] = date2num(times, units=timeVar.units, calendar=timeVar.calendar)
-
+	
 	# Create lat/lon and data variable
+	
+	varName_hres_metadata = varName.split('_')[0]
+	varName = '_'.join(varName.split('_')[1:])
+	
 	if regular_grid == True:
 		latitude = nc.createVariable(lat_name, 'f4', (lat_name))
 		longitude = nc.createVariable(lon_name, 'f4', (lon_name))
@@ -86,7 +90,7 @@ def netCDF(path, filename, varName, data, units, lats, lons, dates, regular_grid
 			var = nc.createVariable(varName, 'f4', (time_name, level_name, lat_name, lon_name,))
 	else:
 		# point[:] = range(len(lats))
-		ids = list(read.hres_metadata(varName)['id'].values)
+		ids = list(read.hres_metadata(varName_hres_metadata)['id'].values)
 		ids = [str(i) for i in ids]
 		maxLenght = 0
 		for x in ids:


### PR DESCRIPTION
CLIMDEX NetCDF Writing: In the function 'postpro_lib.calculate_all_climdex()', the third argument passed is now 'targetVar+'_'+climdex_name' instead of 'climdex_name'. It allows us to identify the 'targetVar' associated with the 'climdex_name'. In the 'write.netCDF()' function, the concatenated strings can be split into two parts separated by the first hyphen, enabling their use in the code."